### PR TITLE
Add standalone deployment support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,69 @@
+# Powerwall3MQTT Standalone Configuration
+# Copy this file to .env and fill in your values
+
+# ====================
+# REQUIRED SETTINGS
+# ====================
+
+# Your Powerwall 3 gateway password (found on the touchscreen or gateway sticker)
+TEDAPI_PASSWORD=your-powerwall-password-here
+
+# MQTT broker hostname or IP address
+MQTT_HOST=192.168.1.100
+
+# MQTT broker port (default: 1883 for non-SSL, 8883 for SSL)
+MQTT_PORT=1883
+
+# ====================
+# OPTIONAL: MQTT AUTHENTICATION
+# ====================
+
+# Uncomment if your MQTT broker requires authentication
+# MQTT_USERNAME=your-mqtt-username
+# MQTT_PASSWORD=your-mqtt-password
+
+# ====================
+# OPTIONAL: MQTT SSL/TLS
+# ====================
+
+# Enable SSL/TLS connection to MQTT broker
+# MQTT_SSL=true
+
+# Path to CA certificate (if using SSL)
+# MQTT_CA_CERT=/certs/ca.crt
+
+# Path to client certificate and key (if using mutual TLS)
+# MQTT_CERT=/certs/client.crt
+# MQTT_KEY=/certs/client.key
+
+# Skip certificate verification (not recommended for production)
+# MQTT_INSECURE=false
+
+# ====================
+# OPTIONAL: MQTT TOPICS
+# ====================
+
+# Base topic for MQTT discovery (default: homeassistant)
+# Change this if you use a different Home Assistant discovery prefix
+MQTT_BASE_TOPIC=homeassistant
+
+# ====================
+# OPTIONAL: POWERWALL POLLING
+# ====================
+
+# How often to poll the Powerwall for updates (in seconds)
+# Range: 1-300, Default: 30
+TEDAPI_POLL_INTERVAL=30
+
+# Report detailed vitals for each Powerwall unit
+# Set to true for per-unit metrics (useful for multi-Powerwall systems)
+# Default: false
+TEDAPI_REPORT_VITALS=false
+
+# ====================
+# OPTIONAL: LOGGING
+# ====================
+
+# Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
+# Default: INFO
+LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.env
 .envrc
 .pyenv
 localdata

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -1,0 +1,26 @@
+FROM alpine:latest
+
+# Install Python and system dependencies
+RUN apk add --no-cache \
+    python3 \
+    py3-pip \
+    py3-yaml \
+    py3-cachetools \
+    py3-requests \
+    py3-protobuf \
+    tini
+
+# Install paho-mqtt via pip (not available in Alpine packages)
+RUN pip3 install --break-system-packages paho-mqtt
+
+# Copy application code
+COPY app /app
+
+# Set working directory
+WORKDIR /app
+
+# Use tini as init system for proper signal handling
+ENTRYPOINT ["/sbin/tini", "--"]
+
+# Run the application
+CMD ["python3", "powerwall3mqtt.py"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # powerwall3mqtt
 A simple Home Assistant Add On that acts as a bridge between the Powerwall 3 TEDAPI and MQTT.
 
+> **Not using Home Assistant OS?** See [STANDALONE.md](STANDALONE.md) for running with Docker Compose.
+
 ## Current state
 - Powerwall 3 local access requires a direct connection to the TeslaPW_XXXXX WiFi network.  The device running this add-on must have an IP from that network, which is 192.168.91.x/24.  A wired ethernet connection **will not work**.
 - The bridge can deal with a single group of one or more Powerwall 3s.  It might also support expansion units, but I have none to test with.

--- a/STANDALONE.md
+++ b/STANDALONE.md
@@ -1,0 +1,108 @@
+# Standalone Deployment
+
+Run Powerwall3MQTT independently without Home Assistant OS, using Docker Compose.
+
+## Why Standalone?
+
+- Run on any Docker-capable system with WiFi access to Powerwall
+- Use with Home Assistant container mode (not HAOS)
+- Integrate with any MQTT broker
+- Deploy on dedicated monitoring devices
+
+## Prerequisites
+
+1. **Docker and Docker Compose** installed
+2. **WiFi connection** to Powerwall WiFi network (`TeslaPW_*` or `TEG-*` SSID)
+   - Must obtain IP in `192.168.91.0/24` range
+   - Wired connection will not work (firmware 25.10.1+ restriction)
+3. **MQTT broker** accessible from Powerwall WiFi network
+4. **Gateway password** from Powerwall touchscreen or sticker
+
+## Quick Start
+
+1. **Clone repository:**
+   ```bash
+   git clone https://github.com/slyglif/powerwall3mqtt.git
+   cd powerwall3mqtt
+   ```
+
+2. **Create configuration:**
+   ```bash
+   cp .env.example .env
+   nano .env
+   ```
+
+   Required settings:
+   ```bash
+   TEDAPI_PASSWORD=your-powerwall-password
+   MQTT_HOST=your-mqtt-broker-ip
+   MQTT_PORT=1883
+   ```
+
+3. **Start service:**
+   ```bash
+   docker-compose up -d
+   ```
+
+4. **Verify operation:**
+   ```bash
+   docker-compose logs -f
+   ```
+
+## Configuration
+
+All settings are configured via `.env` file using environment variables with the `POWERWALL3MQTT_CONFIG_` prefix.
+
+**Required:**
+- `TEDAPI_PASSWORD` - Gateway password
+- `MQTT_HOST` - MQTT broker hostname/IP
+- `MQTT_PORT` - MQTT broker port
+
+**Optional:**
+- `MQTT_USERNAME` / `MQTT_PASSWORD` - MQTT authentication
+- `MQTT_SSL` - Enable SSL/TLS
+- `TEDAPI_POLL_INTERVAL` - Polling frequency (1-300 seconds, default 30)
+- `TEDAPI_REPORT_VITALS` - Per-Powerwall metrics for multi-unit systems
+- `LOG_LEVEL` - Logging verbosity (DEBUG/INFO/WARNING/ERROR/CRITICAL)
+
+See [.env.example](.env.example) for complete list with descriptions.
+
+## Management
+
+```bash
+# Start
+docker-compose up -d
+
+# Stop
+docker-compose down
+
+# Restart
+docker-compose restart
+
+# View logs
+docker-compose logs -f
+
+# Update
+git pull && docker-compose build && docker-compose up -d
+```
+
+## Troubleshooting
+
+See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common issues and solutions.
+
+**Standalone-specific issues:**
+
+- **Container keeps restarting:** Check `.env` file exists and contains required variables
+- **Network mode errors:** Ensure `network_mode: host` is set in `docker-compose.yml`
+
+## Differences from HAOS Add-on
+
+| Feature | Standalone | HAOS Add-on |
+|---------|------------|-------------|
+| Configuration | `.env` file | Web UI |
+| Installation | Git clone + docker-compose | Add-on store |
+| MQTT Integration | Any broker | Auto-configured |
+| Auto-start | Manual (systemd optional) | Built-in |
+| Features | Identical | Identical |
+
+Both versions support the same features: authentication, SSL/TLS, vitals reporting, Home Assistant auto-discovery, and all polling options.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,80 @@
+# Troubleshooting Guide
+
+Common issues and solutions for Powerwall3MQTT.
+
+## Network and Connectivity
+
+### Cannot connect to Powerwall
+
+**Symptom:** Connection refused or timeout errors to `192.168.91.1`
+
+**Solution:**
+- Verify you're connected to the Powerwall WiFi network (SSID: `TeslaPW_*` or `TEG-*`)
+- Check you have an IP in `192.168.91.0/24` range
+- Test connectivity: `ping 192.168.91.1`
+- Verify the Powerwall gateway is powered on
+- Confirm direct WiFi connection (wired/routing will not work with firmware 25.10.1+)
+
+### Empty data / all zeros (Multi-Powerwall systems)
+
+**Symptom:** Logs show `sitemanagerStatus.isRunning: False`, config/status data is empty or all zeros, but firmware version is retrieved successfully
+
+**Root cause:** You may be connected to a **follower Powerwall instead of the leader**
+
+**Solution:**
+- In multi-Powerwall systems, only the leader runs the site manager and has operational data
+- Scan for all Powerwall WiFi networks: `sudo iw dev wlan0 scan | grep "SSID: TeslaPW"`
+- Connect to each `TeslaPW_*` network until you find the one where `sitemanagerStatus.isRunning: true`
+- The leader Powerwall's serial number should match what's shown in the Tesla app
+
+### Authentication failed (Powerwall)
+
+**Symptom:** HTTP 401 errors in logs
+
+**Solution:**
+- Verify password matches your gateway password
+- Check the password on the Powerwall touchscreen: **Settings** → **About**
+- Or check the sticker on the physical gateway device
+
+## MQTT Issues
+
+### Cannot connect to MQTT broker
+
+**Symptom:** Connection refused to MQTT broker
+
+**Solution:**
+- Verify MQTT broker is running: `telnet YOUR_MQTT_HOST 1883`
+- Check MQTT host and port configuration
+- Verify username/password if authentication is enabled
+- Ensure MQTT broker is accessible from the Powerwall WiFi network
+- Check firewall rules on MQTT broker host
+
+### Device not appearing in Home Assistant
+
+**Symptom:** No Powerwall device in MQTT integration
+
+**Solution:**
+- Verify MQTT integration is configured in Home Assistant
+- Check MQTT base topic matches HA discovery prefix (usually `homeassistant`)
+- Monitor MQTT messages: **Developer Tools** → **MQTT** → Listen to `homeassistant/#`
+- Check the logs for "Published discovery" messages
+
+## API and Rate Limiting
+
+### Rate limiting / HTTP 429 errors
+
+**Symptom:** Logs show "Rate limited" or HTTP 429 responses
+
+**Solution:**
+- Increase polling interval to 60 seconds or higher
+- The app will automatically back off when rate limited
+- Wait a few minutes for the Powerwall API to recover
+- Avoid polling intervals below 5 seconds
+
+## Getting Help
+
+When reporting issues, please include:
+- Log output (enable DEBUG logging if possible)
+- Firmware version from logs
+- Network configuration (SSID, IP address)
+- For multi-Powerwall systems: Output showing `sitemanagerStatus`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  powerwall3mqtt:
+    build:
+      context: .
+      dockerfile: Dockerfile.standalone
+    container_name: powerwall3mqtt
+    restart: unless-stopped
+
+    # Use host network mode so the container can access the Powerwall at 192.168.91.1
+    network_mode: host
+
+    environment:
+      # Required: Powerwall gateway password
+      POWERWALL3MQTT_CONFIG_TEDAPI_PASSWORD: "${TEDAPI_PASSWORD}"
+
+      # Required: MQTT broker connection
+      POWERWALL3MQTT_CONFIG_MQTT_HOST: "${MQTT_HOST}"
+      POWERWALL3MQTT_CONFIG_MQTT_PORT: "${MQTT_PORT:-1883}"
+
+      # Optional: MQTT authentication
+      POWERWALL3MQTT_CONFIG_MQTT_USERNAME: "${MQTT_USERNAME:-}"
+      POWERWALL3MQTT_CONFIG_MQTT_PASSWORD: "${MQTT_PASSWORD:-}"
+
+      # Optional: MQTT SSL/TLS
+      POWERWALL3MQTT_CONFIG_MQTT_SSL: "${MQTT_SSL:-false}"
+      # POWERWALL3MQTT_CONFIG_MQTT_CA_CERT: "/certs/ca.crt"
+      # POWERWALL3MQTT_CONFIG_MQTT_CERT: "/certs/client.crt"
+      # POWERWALL3MQTT_CONFIG_MQTT_KEY: "/certs/client.key"
+      # POWERWALL3MQTT_CONFIG_MQTT_INSECURE: "false"
+
+      # Optional: MQTT topic configuration
+      POWERWALL3MQTT_CONFIG_MQTT_BASE_TOPIC: "${MQTT_BASE_TOPIC:-homeassistant}"
+
+      # Optional: Powerwall polling configuration
+      POWERWALL3MQTT_CONFIG_TEDAPI_POLL_INTERVAL: "${TEDAPI_POLL_INTERVAL:-30}"
+      POWERWALL3MQTT_CONFIG_TEDAPI_REPORT_VITALS: "${TEDAPI_REPORT_VITALS:-false}"
+
+      # Optional: Logging
+      POWERWALL3MQTT_CONFIG_LOG_LEVEL: "${LOG_LEVEL:-INFO}"
+
+    # Uncomment if you need to mount certificates for MQTT SSL
+    # volumes:
+    #   - ./certs:/certs:ro


### PR DESCRIPTION
I found this repo to be incredibly helpful integrating my new powerwall3's into home assistant.  However, since I don't run home assistant in HAOS, but instead as a vanilla docker container, the 'add-on' installation wasn't an option for me.

So, this commit documents what I did to enable it in my environment, including another dockerfile and a docker-compose example.  I'm not sure that they really belong at this top level, or, perhaps you have no interest in supporting non-HAOS installations, but, I thought I'd submit and let you take a look.  Happy to refactor based on any feedback.